### PR TITLE
Add `match()` method for pattern matching on `Result`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,9 +3,8 @@ on:
   push:
     branches: [main]
     # Ignore all markdown files, all files in the .github directory (but not its
-    # workflows/ directory), and test files. 
+    # workflows/ directory), and test files.
     paths-ignore: ['**.md', '.github/*']
-
 
 jobs:
 
@@ -47,7 +46,6 @@ jobs:
             echo "::set-output name=npm_tag::latest"
           fi
 
-
   # job: publish_github_package
   publish_github_package:
     name: Publish NPM package to Github
@@ -75,7 +73,6 @@ jobs:
       - run: npm publish --tag ${{needs.create_version.outputs.npm_tag}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
   # job: publish_npm_package
   publish_npm_package:

--- a/deno/result.match.test.ts
+++ b/deno/result.match.test.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from '../test_deps.ts';
+import { Result } from '../mod.ts';
+
+/** Example function that increments a number if it is positive and returns an
+ * error otherwise. */
+function maybeIncrementPositive(x: number): Result<number, string> {
+  if (x > 0) {
+    return Result.ok(x + 1);
+  } else {
+    return Result.error('fail');
+  }
+}
+
+Deno.test({
+  name: 'Result.ok(x).match({ok, error}) returns ok(x)',
+  fn: () => {
+    const n = maybeIncrementPositive(1).match({
+      ok: (x) => x + 1,
+      error: () => 0,
+    });
+
+    assertEquals(n, 3);
+  },
+});
+
+Deno.test({
+  name: 'Result.error(x).match({ok, error}) returns error(x)',
+  fn: () => {
+    const n = maybeIncrementPositive(0).match({
+      ok: () => 0,
+      error: (e) => e.length,
+    });
+
+    assertEquals(n, 4);
+  },
+});

--- a/src/result.ts
+++ b/src/result.ts
@@ -28,6 +28,23 @@
  *
  * // Use Result with a function
  * myResultFunction(r); // prints: r3 is error with value of: -7
+ *
+ * // Pattern match on Result
+ * const r4 = Result.ok(5);
+ * const r5 = r4.match({
+ *   ok: (x) => `ok with value ${x}`,
+ *   error: (y) => `error with value ${y}`,
+ * });
+ * console.log(r5); // prints: ok with value 5
+ *
+ * // Or something like this, where the pattern match doesn't return a value
+ * // but instead performs an action
+ *
+ * const r6 = Result.error(10);
+ * r6.match({
+ *   ok: (x) => console.log(`ok with value ${x}`),
+ *   error: (y) => console.log(`error with value ${y}`),
+ * }); // prints: error with value 10
  * ```
  */
 export class Result<Ok, Error> {
@@ -147,9 +164,7 @@ export class Result<Ok, Error> {
   /** Maps `Error` type or throws an `Error` if result is not ok */
   public mapEmptyError<E>(): Result<Ok, E> {
     if (this.isError()) {
-      throw new ResultError(
-        `Can't mapEmptyErr for when error isn't empty`,
-      );
+      throw new ResultError(`Can't mapEmptyErr for when error isn't empty`);
     }
     return this as unknown as Result<Ok, E>;
   }
@@ -161,9 +176,7 @@ export class Result<Ok, Error> {
   }
 
   /** Calls `f` if the result is Ok, otherwise returns the Error value of itself. */
-  public andThen<O>(
-    f: (x: Ok) => Result<O, Error>,
-  ): Result<O, Error> {
+  public andThen<O>(f: (x: Ok) => Result<O, Error>): Result<O, Error> {
     if (this.isOk()) return f(this.value as Ok);
     else return this.mapEmptyOk();
   }
@@ -182,12 +195,18 @@ export class Result<Ok, Error> {
 
   /** Returns the inner Ok value or undefined if value is Error */
   public ok(): Ok | undefined {
-    return this.isOkInner ? this.value as Ok : undefined;
+    return this.isOkInner ? (this.value as Ok) : undefined;
   }
 
   /** Returns the inner Error value or undefined if value is Ok */
   public error(): Error | undefined {
-    return this.isOkInner ? undefined : this.value as Error;
+    return this.isOkInner ? undefined : (this.value as Error);
+  }
+
+  /** Pattern match on the Result. */
+  public match<O>(m: { ok: (x: Ok) => O; error: (x: Error) => O }): O {
+    if (this.isOk()) return m.ok(this.unwrap());
+    else return m.error(this.unwrapError());
   }
 }
 


### PR DESCRIPTION
This PR adds a `match()` method that lets you handle both `ok` and `error` branches in a single call, similar to Rust's `match` on `Result`.

```typescript
function maybeIncrementPositive(x: number): Result<number, string> {
  if (x > 0) {
    return Result.ok(x + 1);
  } else {
    return Result.error("fail");
  }
}

const n = maybeIncrementPositive(0).match({
  ok: (x) => x,
  error: (e) => e.length,
});
// n === 4
```

This avoids needing to chain `.isOk()` checks or unwrap manually when you want to transform both variants into a single value.